### PR TITLE
Add Support for Passing OTP Code to Docker via pyotp

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,14 @@ or
 ```sh
 docker run --rm --env NO_IP_USERNAME=<EMAIL> --env NO_IP_PASSWORD=<PASSWORD> simaofsilva/noip-renewer:<TAG> 
 ```
+or with OTP
+```sh
+docker run --rm --env NO_IP_USERNAME=<EMAIL> --env NO_IP_PASSWORD=<PASSWORD> --env NO_IP_OTP_KEY=<NO IP OTP KEY> simaofsilva/noip-renewer:<TAG> 
+```
 or with 2FA
 ```sh
 docker run --rm --env NO_IP_USERNAME=<EMAIL> --env NO_IP_PASSWORD=<PASSWORD> --env NO_IP_TOTP_KEY=<NOIP TOTP KEY> simaofsilva/noip-renewer:<TAG> 
 ```
-
 or with translation disabled
 ```sh
 docker run --rm --env NO_IP_USERNAME=<EMAIL> --env NO_IP_PASSWORD=<PASSWORD> --env TRANSLATE_ENABLED=false simaofsilva/noip-renewer:<TAG> 

--- a/renew.py
+++ b/renew.py
@@ -173,7 +173,9 @@ if __name__ == "__main__":
 
             # Account has email verification code
             if CODE_METHOD == "email":
-                otp_code = str(input("Enter OTP code: ")).replace("\n", "")
+                otp_code = os.getenv("NO_IP_OTP_KEY", "")
+                if len(otp_code) == 0:
+                    otp_code = str(input("Enter OTP code: ")).replace("\n", "")
                 if validate_otp(otp_code):
                     code_inputs = code_form.find_elements(by=By.TAG_NAME, value="input")
                     if len(code_inputs) == 6:


### PR DESCRIPTION
Make docker to be able to pass OTP code instead of only manual typing. 
For example, using pyotp to get otp code from otpauth url before that, and pass this code to docker. In this way, the way of authentication can be use multiple times rather than manual update TOTP code. 

This update enhances the authentication process by allowing Docker to pass an OTP code automatically instead of requiring manual input. The new functionality uses the pyotp library to generate an OTP code from a provided otpauth URL. This allows for a more streamlined and repeatable authentication process, eliminating the need to manually update the TOTP code for each authentication attempt.